### PR TITLE
Fix-up Vagrantfile for use on mac with vmware-fusion

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if $use_nfs == "true"
     	# this will override the default '/vagrant' shared folder settings and use nfs
-    	config.vm.synced_folder ".", "/vagrant"#, type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+    	config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
     end
 
     config.vm.define "opdk" do |opdk|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.vbguest.auto_update = false
     end
 
+    if $use_nfs == "true"
+    	# this will override the default '/vagrant' shared folder settings and use nfs
+    	config.vm.synced_folder ".", "/vagrant"#, type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+    end
+
     config.vm.define "opdk" do |opdk|
 
       opdk.vm.box = "stackinabox/openstack"
@@ -85,11 +90,37 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           vb.customize ['modifyvm', :id, '--cableconnected3', 'on']
       end
 
-            opdk.vm.provider :vmware_workstation do |vw|
-              vw.name = "stackinabox" # sets the name that virtual box will show in it's UI
-              vw.vmx["numvcpus"] = "#{$cpus}" # set number of vcpus
-              vw.vmx["memsize"] = "#{$memory}" # set amount of memory allocated vm memory
-            end
+      opdk.vm.provider :vmware_desktop do |vw|
+          vw.vmx["displayName"] = "stackinabox" # sets the name that virtual box will show in it's UI
+          vw.vmx["numvcpus"] = "#{$cpus}" # set number of vcpus
+          vw.vmx["memsize"] = "#{$memory}" # set amount of memory allocated vm memory
+          vw.vmx["guestOS"] = "ubuntu-64"
+          vw.vmx["vhv.enable"] = "TRUE"
+          vw.vmx["vmx.allowNested"] = "TRUE"
+          vw.vmx["mainMem.allow8GB"] = "TRUE"
+          vw.vmx["vmx.superPriorityBoost"] = "TRUE"
+          vw.vmx["RemoteDisplay.vnc.enabled"] = "FALSE"
+
+          vw.vmx["ethernet0.present"] = "TRUE"
+          vw.vmx["ethernet0.startConnected"] = "TRUE"
+          vw.vmx["ethernet0.virtualDev"] = "vmxnet"
+          vw.vmx["ethernet0.connectionType"] = "nat"
+          vw.vmx["ethernet0.addresstype"] = "generated"
+
+          vw.vmx["ethernet1.present"] = "TRUE"
+          vw.vmx["ethernet1.startConnected"] = "TRUE"
+          vw.vmx["ethernet1.virtualDev"] = "vmxnet"
+          vw.vmx["ethernet1.connectionType"] = "custom"
+          vw.vmx["ethernet1.vnet"] = "vmnet2"
+          vw.vmx["ethernet1.addresstype"] = "generated"
+
+          vw.vmx["ethernet2.present"] = "TRUE"
+          vw.vmx["ethernet2.startConnected"] = "TRUE"
+          vw.vmx["ethernet2.virtualDev"] = "vmxnet"
+          vw.vmx["ethernet2.connectionType"] = "custom"
+          vw.vmx["ethernet2.vnet"] = "vmnet3"
+          vw.vmx["ethernet2.addresstype"] = "generated"
+      end
 
     end
 


### PR DESCRIPTION
I was unable to run the `vmwareprovider` branch "as-is" on my mac with vmware fusion 6 and the `vagrant-vmware-fusion` provider plugin.  I had to upgrade my vmware fusion to 8.5.3 (newest available now) and my `vagrant-vmware-fusion` provider license and make a few changes to the `Vagrantfile` to get it to work. I'm using `vmware_desktop` as the `provider` name in the `Vagrantfile` as that should work for both `vmware_fusion` and `vmware_workstation` providers when supplied with the `--provider=vmware_fusion` &/or `--provider=vmware_workstation` flags when running "vagrant up" from the command line.

Please check out the changes and test on a Linux machine to make sure my changes for `vmware-fusion` don't break when run on a linux box under vmware workstation.